### PR TITLE
FLOE-274: Added an unsupported message to demo

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -69,23 +69,30 @@
         </div>
         <script type="text/javascript">
             $(document).ready(function () {
-                fluid.prefs.create("#gpiic-fd", {
-                    build: {
-                        gradeNames: ["gpii.firstDiscovery.auxSchema"]
-                    },
-                    prefsEditor: {
-                        prefsEditorType: "gpii.firstDiscovery.firstDiscoveryEditor",
-                        components: {
-                            prefsEditorLoader: {
-                                options: {
-                                    model: {
-                                        currentPanelNum: 3   // show the text size panel at the page load
+                var container = $("#gpiic-fd");
+                var unsupportedText = "This web browser is not supported. Please try using the latest version of Chrome or Safari.";
+
+                if (fluid.textToSpeech.isSupported()) {
+                    fluid.prefs.create(container, {
+                        build: {
+                            gradeNames: ["gpii.firstDiscovery.auxSchema"]
+                        },
+                        prefsEditor: {
+                            prefsEditorType: "gpii.firstDiscovery.firstDiscoveryEditor",
+                            components: {
+                                prefsEditorLoader: {
+                                    options: {
+                                        model: {
+                                            currentPanelNum: 3   // show the text size panel at the page load
+                                        }
                                     }
                                 }
                             }
                         }
-                    }
-                });
+                    });
+                } else {
+                    container.text(unsupportedText);
+                }
             });
         </script>
     </body>

--- a/demos/index.html
+++ b/demos/index.html
@@ -70,7 +70,7 @@
         <script type="text/javascript">
             $(document).ready(function () {
                 var container = $("#gpiic-fd");
-                var unsupportedText = "This web browser is not supported. Please try using the latest version of Chrome or Safari.";
+                var unsupportedText = "This browser is currently not supported. Please try using the latest version of Chrome or Safari.";
 
                 if (fluid.textToSpeech.isSupported()) {
                     fluid.prefs.create(container, {


### PR DESCRIPTION
For browsers that don't support the SpeechSynthesis Interface from the Web Speech API, a message stating that the browser is not supported is displayed instead of instantiating the First Discovery Tool.

http://issues.fluidproject.org/browse/FLOE-274