### PR TITLE
FLOE-277: Disabled the increase/decrease buttons

### DIFF
--- a/src/js/panels.js
+++ b/src/js/panels.js
@@ -71,6 +71,10 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 "method": "click",
                 "args": ["{that}.stepDown"]
             },
+            "afterRender.updateButtonState": {
+                listener: "gpii.firstDiscovery.panel.ranged.updateButtonState",
+                args: ["{that}"]
+            },
             "afterRender.updateMeter": "{that}.updateMeter",
             "afterRender.updateTooltipModel": {
                 listener: "{that}.tooltip.applier.change",
@@ -82,10 +86,13 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             }
         },
         modelListeners: {
-            "value": {
+            "value": [{
                 listener: "{that}.updateMeter",
                 excludeSource: ["init"]
-            }
+            }, {
+                listener: "gpii.firstDiscovery.panel.ranged.updateButtonState",
+                args: ["{that}"]
+            }]
         }
     });
 
@@ -102,6 +109,14 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         var newValue = that.model.value + step;
         newValue = gpii.firstDiscovery.panel.ranged.clip(newValue, that.options.range.min, that.options.range.max);
         that.applier.change("value", newValue);
+    };
+
+    gpii.firstDiscovery.panel.ranged.updateButtonState = function (that) {
+        var isMax = that.model.value >= that.options.range.max;
+        var isMin = that.model.value <= that.options.range.min;
+
+        that.locate("increase").prop("disabled", isMax);
+        that.locate("decrease").prop("disabled", isMin);
     };
 
     gpii.firstDiscovery.panel.ranged.calculatePercentage = function (value, min, max) {

--- a/tests/js/panelsTests.js
+++ b/tests/js/panelsTests.js
@@ -129,12 +129,13 @@ https://github.com/gpii/universal/LICENSE.txt
         gradeNames: ["fluid.test.testCaseHolder", "autoInit"],
         testOptions: {
             increasedStep: 1.1,
-            decreasedStep: 1.0
+            decreasedStep: 1.0,
+            testValue: 1.5
         },
         modules: [{
             name: "Test the text sizer settings panel",
             tests: [{
-                expect: 9,
+                expect: 11,
                 name: "Test the rendering of the text size panel",
                 sequence: [{
                     func: "{textSize}.refreshView"
@@ -169,6 +170,14 @@ https://github.com/gpii/universal/LICENSE.txt
                 }, {
                     listener: "gpii.tests.textSizeTester.verifyButtonStates",
                     args: ["{textSize}", false, true],
+                    spec: {path: "value", priority: "last"},
+                    changeEvent: "{textSize}.applier.modelChanged"
+                }, {
+                    func: "{textSize}.applier.change",
+                    args: ["value", "{that}.options.testOptions.testValue"]
+                }, {
+                    listener: "gpii.tests.textSizeTester.verifyButtonStates",
+                    args: ["{textSize}", false, false],
                     spec: {path: "value", priority: "last"},
                     changeEvent: "{textSize}.applier.modelChanged"
                 }]

--- a/tests/js/panelsTests.js
+++ b/tests/js/panelsTests.js
@@ -134,7 +134,7 @@ https://github.com/gpii/universal/LICENSE.txt
         modules: [{
             name: "Test the text sizer settings panel",
             tests: [{
-                expect: 5,
+                expect: 9,
                 name: "Test the rendering of the text size panel",
                 sequence: [{
                     func: "{textSize}.refreshView"
@@ -155,6 +155,22 @@ https://github.com/gpii/universal/LICENSE.txt
                     args: ["{textSize}", "{that}.options.testOptions.decreasedStep"],
                     spec: {path: "value", priority: "last"},
                     changeEvent: "{textSize}.applier.modelChanged"
+                }, {
+                    func: "{textSize}.applier.change",
+                    args: ["value", "{textSize}.options.range.max"]
+                }, {
+                    listener: "gpii.tests.textSizeTester.verifyButtonStates",
+                    args: ["{textSize}", true, false],
+                    spec: {path: "value", priority: "last"},
+                    changeEvent: "{textSize}.applier.modelChanged"
+                }, {
+                    func: "{textSize}.applier.change",
+                    args: ["value", "{textSize}.options.range.min"]
+                }, {
+                    listener: "gpii.tests.textSizeTester.verifyButtonStates",
+                    args: ["{textSize}", false, true],
+                    spec: {path: "value", priority: "last"},
+                    changeEvent: "{textSize}.applier.modelChanged"
                 }]
             }]
         }]
@@ -168,6 +184,11 @@ https://github.com/gpii/universal/LICENSE.txt
 
     gpii.tests.textSizeTester.verifyModel = function (that, expectedModel) {
         jqUnit.assertEquals("The model value should be set correctly", expectedModel, that.model.value);
+    };
+
+    gpii.tests.textSizeTester.verifyButtonStates = function (that, increaseDisabled, decreaseDisabled) {
+        jqUnit.assertEquals("The increase button should have the correct enabled/disabled state", increaseDisabled, that.locate("increase").prop("disabled"));
+        jqUnit.assertEquals("The decrease button should have the correct enabled/disabled state", decreaseDisabled, that.locate("decrease").prop("disabled"));
     };
 
     $(document).ready(function () {


### PR DESCRIPTION
The increase and decrease buttons will be disabled when their respective extreme has been reached.

http://issues.fluidproject.org/browse/FLOE-277

The styling of the disabled buttons is provided in https://github.com/fluid-project/first-discovery/pull/21