### PR TITLE
FLOE-303: Added simple sticky keys assessment

### DIFF
--- a/src/js/stickyKeysAssessment.js
+++ b/src/js/stickyKeysAssessment.js
@@ -18,13 +18,11 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     fluid.defaults("gpii.firstDiscovery.keyboard.stickyKeysAssessment", {
         gradeNames: ["fluid.modelRelayComponent", "autoInit"],
         model: {
-            input: "",
+            // input: "", the input value to compare against the expected input.
             offerAssistance: false
         },
         modelRelay: {
             target: "offerAssistance",
-            barckward: "never",
-            forward: "liveOnly",
             singleTransform: {
                 type: "fluid.transforms.free",
                 args: {
@@ -35,11 +33,12 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 func: "gpii.firstDiscovery.keyboard.stickyKeysAssessment.check"
             }
         },
+        // A valid string must be supplied by integrator
         requiredInput: ""
     });
 
     gpii.firstDiscovery.keyboard.stickyKeysAssessment.check = function (model) {
-        return model.offerAssistance || model.input !== model.requiredInput;
+        return model.offerAssistance || model.input && model.input !== model.requiredInput;
     };
 
 })(jQuery, fluid);

--- a/src/js/stickyKeysAssessment.js
+++ b/src/js/stickyKeysAssessment.js
@@ -1,0 +1,46 @@
+/*
+Copyright 2015 OCAD University
+
+Licensed under the Educational Community License (ECL), Version 2.0 or the New
+BSD license. You may not use this file except in compliance with one these
+Licenses.
+
+You may obtain a copy of the ECL 2.0 License and BSD License at
+https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
+*/
+
+(function ($, fluid) {
+
+    "use strict";
+
+    fluid.registerNamespace("gpii.firstDiscovery.keyboard");
+
+    fluid.defaults("gpii.firstDiscovery.keyboard.stickyKeysAssessment", {
+        gradeNames: ["fluid.modelRelayComponent", "autoInit"],
+        model: {
+            input: "",
+            offerAssistance: false
+        },
+        modelRelay: {
+            source: "input",
+            target: "offerAssistance",
+            barckward: "never",
+            forward: "liveOnly",
+            singleTransform: {
+                type: "fluid.transforms.free",
+                args: {
+                    "input": "{that}.model.input",
+                    "offerAssistance": "{that}.model.offerAssistance",
+                    "requiredInput": "{that}.options.requiredInput"
+                },
+                func: "gpii.firstDiscovery.keyboard.stickyKeysAssessment.check"
+            }
+        },
+        requiredInput: ""
+    });
+
+    gpii.firstDiscovery.keyboard.stickyKeysAssessment.check = function (model) {
+        return model.offerAssistance || model.input !== model.requiredInput;
+    };
+
+})(jQuery, fluid);

--- a/src/js/stickyKeysAssessment.js
+++ b/src/js/stickyKeysAssessment.js
@@ -22,7 +22,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             offerAssistance: false
         },
         modelRelay: {
-            source: "input",
             target: "offerAssistance",
             barckward: "never",
             forward: "liveOnly",

--- a/tests/all-tests.html
+++ b/tests/all-tests.html
@@ -17,6 +17,7 @@
         "./html/selfVoicing-Tests.html",
         "./html/navButtons-Tests.html",
         "./html/navIcons-Tests.html",
+        "./html/stickyKeysAssessment-Tests.html",
         "./html/panels-Tests.html",
         "./html/firstDiscoveryEditor-Tests.html"
     ]);

--- a/tests/html/stickyKeysAssessment-Tests.html
+++ b/tests/html/stickyKeysAssessment-Tests.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <title>Sticky Keys Assessment Tests</title>
+
+        <link rel="stylesheet" media="screen" href="../lib/infusion/lib/qunit/css/qunit.css" />
+
+        <script src="../lib/infusion/lib/qunit/js/qunit.js"></script>
+        <script src="../../src/lib/infusion/infusion-custom.js"></script>
+        <script src="../lib/infusion/test-core/jqUnit/js/jqUnit.js"></script>
+        <script src="../lib/infusion/test-core/utils/js/IoCTestUtils.js"></script>
+
+        <script src="../../src/js/stickyKeysAssessment.js"></script>
+        <script src="../js/stickyKeysAssessmentTests.js"></script>
+    </head>
+
+    <body id="body">
+        <h1 id="qunit-header">Sticky Keys Assessment Tests</h1>
+        <h2 id="qunit-banner"></h2>
+        <div id="qunit-testrunner-toolbar"></div>
+        <h2 id="qunit-userAgent"></h2>
+        <ol id="qunit-tests"></ol>
+
+    </body>
+</html>

--- a/tests/js/stickyKeysAssessmentTests.js
+++ b/tests/js/stickyKeysAssessmentTests.js
@@ -1,0 +1,55 @@
+/*!
+Copyright 2015 OCAD University
+
+Licensed under the New BSD license. You may not use this file except in
+compliance with this License.
+
+You may obtain a copy of the License at
+https://github.com/gpii/universal/LICENSE.txt
+*/
+
+(function ($, fluid) {
+    "use strict";
+
+    fluid.registerNamespace("gpii.tests");
+
+    /**************************
+     * Sticky Keys Assessment *
+     **************************/
+
+    fluid.defaults("gpii.tests.firstDiscovery.keyboard.stickyKeysAssessment", {
+        gradeNames: ["gpii.firstDiscovery.keyboard.stickyKeysAssessment", "autoInit"],
+        requiredInput: "@"
+    });
+
+    gpii.tests.firstDiscovery.keyboard.stickyKeysAssessment.checkTestModels = [
+        {offerAssistance: false, input: "a", requiredInput: "b", expected: true},
+        {offerAssistance: true, input: "a", requiredInput: "b", expected: true},
+        {offerAssistance: false, input: "a", requiredInput: "a", expected: false},
+        {offerAssistance: true, input: "a", requiredInput: "a", expected: true}
+    ];
+
+    jqUnit.test("gpii.firstDiscovery.keyboard.stickyKeysAssessment.check", function () {
+        var msg = "offerAssistance: %offerAssistance, input: %input, requiredInput: %requiredInput";
+        fluid.each(gpii.tests.firstDiscovery.keyboard.stickyKeysAssessment.checkTestModels, function (model) {
+            var result = gpii.firstDiscovery.keyboard.stickyKeysAssessment.check(model);
+            jqUnit.assertEquals(fluid.stringTemplate(msg, model), model.expected, result);
+        });
+    });
+
+    jqUnit.test("gpii.firstDiscovery.keyboard.stickyKeysAssessment", function () {
+        var that = gpii.tests.firstDiscovery.keyboard.stickyKeysAssessment();
+
+        jqUnit.assertFalse("Initially offerAssistance should be false", that.model.offerAssistance);
+
+        that.applier.change("input", "@");
+        jqUnit.assertFalse("After entering the expected input, offerAssistance should still be false", that.model.offerAssistance);
+
+        that.applier.change("input", "2");
+        jqUnit.assertTrue("After entering an unexpected input, offerAssistance should be true", that.model.offerAssistance);
+
+        that.applier.change("input", "@");
+        jqUnit.assertTrue("After entering the expected input, offerAssistance should still be true", that.model.offerAssistance);
+    });
+
+})(jQuery, fluid);


### PR DESCRIPTION
Added a simple sticky key assessment component. All it does is compare an input value with a predefined required value. This can be used later to see if an "@" is accurately entered, although that entry capture will need to be handled by a different component.

http://issues.fluidproject.org/browse/FLOE-303