### PR TITLE
FLOE-322: Fix some text in the interface

### DIFF
--- a/src/html/rangeTemplate.html
+++ b/src/html/rangeTemplate.html
@@ -1,10 +1,10 @@
 <p class="gpiic-fd-instructions gpii-fd-instructions"></p>
 <div class="row gpii-fd-controls">
     <div class="row">
-        <div class="small-offset-2 small-1 columns gpii-fd-label-max">max</div>
+        <div class="small-offset-3 small-1 columns gpii-fd-label-max">max</div>
     </div>
     <div class="row">
-        <div class="small-offset-3 small-1 columns gpii-fd-status">
+        <div class="small-offset-4 small-1 columns gpii-fd-status">
             <div class="gpii-fd-statusFillMin"></div>
             <div class="gpii-fd-statusFillContainer">
                 <div class="gpiic-fd-range-indicator gpii-fd-statusFill"></div>
@@ -13,15 +13,13 @@
         <div class="small-7 medium-6 end columns">
             <div class="row">
                 <button class="gpiic-fd-range-increase left gpii-fd-increase" id="gpiic-fd-increase" name="increase" tabindex="1"><span class="gpii-fd-icon"></span></button>
-                <label class="gpiic-fd-range-increaseLabel gpii-fd-control-label" for="gpiic-fd-increase"></label>
             </div>
             <div class="row">
                 <button class="gpiic-fd-range-decrease left gpii-fd-decrease" id="gpiic-fd-decrease" name="decrease" tabindex="1"><span class="gpii-fd-icon"></span></button>
-                <label class="gpiic-fd-range-decreaseLabel gpii-fd-control-label" for="gpiic-fd-decrease"></label>
             </div>
         </div>
     </div>
     <div class="row">
-        <div class="small-offset-2 small-1 columns gpii-fd-label-min">min</div>
+        <div class="small-offset-3 small-1 columns gpii-fd-label-min">min</div>
     </div>
 </div>

--- a/src/html/welcomeTemplate.html
+++ b/src/html/welcomeTemplate.html
@@ -1,1 +1,1 @@
-<div class="gpiic-fd-instructions"></div>
+<div class="gpiic-fd-instructions gpii-fd-instructions"></div>

--- a/src/js/panels.js
+++ b/src/js/panels.js
@@ -44,9 +44,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             rangeInstructions: ".gpiic-fd-instructions",
             meter: ".gpiic-fd-range-indicator",
             increase: ".gpiic-fd-range-increase",
-            increaseLabel: ".gpiic-fd-range-increaseLabel",
-            decrease: ".gpiic-fd-range-decrease",
-            decreaseLabel: ".gpiic-fd-range-decreaseLabel"
+            decrease: ".gpiic-fd-range-decrease"
         },
         selectorsToIgnore: ["meter", "increase", "decrease"],
         tooltipContentMap: {
@@ -54,9 +52,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             "decrease": "decreaseLabel"
         },
         protoTree: {
-            rangeInstructions: {messagekey: "rangeInstructions"},
-            increaseLabel: {messagekey: "increaseLabel"},
-            decreaseLabel: {messagekey: "decreaseLabel"}
+            rangeInstructions: {messagekey: "rangeInstructions"}
         },
         invokers: {
             stepUp: {

--- a/src/messages/firstDiscovery.json
+++ b/src/messages/firstDiscovery.json
@@ -3,8 +3,8 @@
     "backTooltip": "Select to go back to last step",
     "next": "next",
     "nextTooltip": "Select to go to next step",
-    "start": "start",
-    "startTooltip": "Select to start",
+    "start": "continue",
+    "startTooltip": "Select to continue",
     "finish": "finish",
     "finishTooltip": "Select to finish",
 

--- a/src/messages/welcome.json
+++ b/src/messages/welcome.json
@@ -1,3 +1,3 @@
 {
-    "message": "<p>Welcome!</p> <p>If you need help at any time, press the H key. To continue, select the start button below.</p>"
+    "message": "<p>Welcome!</p> <p>This tool will guide you through setting up your computer the way you like it best.</p> <p>For help at any time, press the H key. To continue, select the next button or press the N key.</p>"
 }

--- a/tests/js/panelsTests.js
+++ b/tests/js/panelsTests.js
@@ -248,7 +248,7 @@ https://github.com/gpii/universal/LICENSE.txt
         modules: [{
             name: "Test the text sizer settings panel",
             tests: [{
-                expect: 13,
+                expect: 11,
                 name: "Test the rendering of the text size panel",
                 sequence: [{
                     func: "{textSize}.refreshView"
@@ -302,8 +302,6 @@ https://github.com/gpii/universal/LICENSE.txt
     gpii.tests.textSizeTester.verifyRendering = function (that) {
         var messages = that.options.messageBase;
         jqUnit.assertEquals("The text for instructions should be rendered.", messages.rangeInstructions, that.locate("rangeInstructions").text());
-        jqUnit.assertEquals("The text for increase button should be rendered.", messages.increaseLabel, that.locate("increaseLabel").text());
-        jqUnit.assertEquals("The text for decrease button should be rendered.", messages.decreaseLabel, that.locate("decreaseLabel").text());
 
         var increaseId = that.locate("increase").attr("id");
         var decreaseId = that.locate("decrease").attr("id");


### PR DESCRIPTION
This pull request fixes the following:
- on opening Language screen, the button should say "continue"
- the Welcome screen text is incomplete, and should reference the "next" button and not the "start" button
- on the text size screen, we should not have labels on the +/- buttons
These changes are based on the latest designs