### PR TITLE
FLOE-325: Adding reset shortcut

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -13,6 +13,7 @@
         <link rel="stylesheet" type="text/css" href="../src/lib/infusion/src/framework/preferences/css/PrefsEditor.css" />
 
         <script type="text/javascript" src="../src/lib/infusion/infusion-custom.js"></script>
+        <script type="text/javascript" src="../src/js/keyboardShortcut.js"></script>
         <script type="text/javascript" src="../src/js/ttsHookup.js"></script>
         <script type="text/javascript" src="../src/js/tooltip.js"></script>
         <script type="text/javascript" src="../src/js/msgLookup.js"></script>

--- a/src/js/firstDiscoveryEditor.js
+++ b/src/js/firstDiscoveryEditor.js
@@ -47,7 +47,22 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                             listener: "{firstDiscoveryEditor}.events.onPrefsEditorReady",
                             args: "{firstDiscoveryEditor}"
                         },
-                        onAutoSave: "{that}.saveAndApply"
+                        onAutoSave: "{that}.saveAndApply",
+                        // the page is reloaded to reset language and etc.
+                        "onReset.reload": {
+                            "this": "location",
+                            method: "reload",
+                            args: true
+                        },
+                        "onCreate.bindResetShortcut": {
+                            listener: "gpii.firstDiscovery.keyboardShortcut.bindShortcut",
+                            args: [
+                                "body",
+                                gpii.firstDiscovery.keyboardShortcut.key.r,
+                                ["ctrlKey", "altKey"],
+                                "{that}.reset"
+                            ]
+                        }
                     },
                     autoSave: true,
                     connectionGradeForLang: "gpii.firstDiscovery.panel.lang.prefEditorConnection",

--- a/src/js/keyboardShortcut.js
+++ b/src/js/keyboardShortcut.js
@@ -47,7 +47,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     gpii.firstDiscovery.keyboardShortcut.modfiers = ["altKey", "ctrlKey", "metaKey", "shiftKey"];
 
     /**
-     * elm {Object} - any jQueryable selector refering to the element to bind a keypress to
+     * elm {Object} - any jQueryable selector referring to the element to bind a keypress to
      * key {Int} - An integer representation of the key to bind as a shortcut (see: gpii.firstDiscovery.keyboardShortcut.key)
      * modifiers {Array} - an array of modifiers required ("altKey", "ctrlKey", "metaKey", "shiftKey")
      * func {Object} - the function to call when the shortcut is triggered.

--- a/src/js/keyboardShortcut.js
+++ b/src/js/keyboardShortcut.js
@@ -1,0 +1,71 @@
+/*
+Copyright 2015 OCAD University
+
+Licensed under the Educational Community License (ECL), Version 2.0 or the New
+BSD license. You may not use this file except in compliance with one these
+Licenses.
+
+You may obtain a copy of the ECL 2.0 License and BSD License at
+https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
+*/
+
+(function ($, fluid) {
+
+    "use strict";
+
+    fluid.registerNamespace("gpii.firstDiscovery.keyboardShortcut");
+
+    gpii.firstDiscovery.keyboardShortcut.key = {
+        a: 65,
+        b: 66,
+        c: 67,
+        d: 68,
+        e: 69,
+        f: 70,
+        g: 71,
+        h: 72,
+        i: 73,
+        j: 74,
+        k: 75,
+        l: 76,
+        m: 77,
+        n: 78,
+        o: 79,
+        p: 80,
+        q: 81,
+        r: 82,
+        s: 83,
+        t: 84,
+        u: 85,
+        v: 86,
+        w: 87,
+        x: 88,
+        y: 89,
+        z: 90
+    };
+
+    gpii.firstDiscovery.keyboardShortcut.modfiers = ["altKey", "ctrlKey", "metaKey", "shiftKey"];
+
+    /**
+     * elm {Object} - any jQueryable selector refering to the element to bind a keypress to
+     * key {Int} - An integer representation of the key to bind as a shortcut (see: gpii.firstDiscovery.keyboardShortcut.key)
+     * modifiers {Array} - an array of modifiers required ("altKey", "ctrlKey", "metaKey", "shiftKey")
+     * func {Object} - the function to call when the shortcut is triggered.
+     */
+    gpii.firstDiscovery.keyboardShortcut.bindShortcut = function (elm, key, modifiers, func) {
+        modifiers = fluid.arrayToHash(modifiers || []);
+
+        $(elm).keydown(function (e) {
+            var checkModifier = function (modKey, current) {
+                return current && !!e[modKey] === !!modifiers[modKey]; /* convert to boolean */ /* jshint ignore:line */
+            };
+
+            var isCorrectlyModified = fluid.accumulate(gpii.firstDiscovery.keyboardShortcut.modfiers, checkModifier, true);
+
+            if (e.which === key && isCorrectlyModified) {
+                func();
+            }
+        });
+    };
+
+})(jQuery, fluid);

--- a/src/js/ttsHookup.js
+++ b/src/js/ttsHookup.js
@@ -63,9 +63,8 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                     },
                     listeners: {
                         "onCreate.bindKeypress": {
-                            listener: "gpii.firstDiscovery.tts.fdHookup.bindKeypress",
-                            // 104 === 'h'
-                            args: ["body", 104, "{that}.speakPanelInstructions"]
+                            listener: "gpii.firstDiscovery.keyboardShortcut.bindShortcut",
+                            args: ["body", gpii.firstDiscovery.keyboardShortcut.key.h, [], "{that}.speakPanelInstructions"]
                         }
                     },
                     modelListeners: {
@@ -76,14 +75,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         },
         panelInstructionsSelector: ".gpiic-fd-instructions"
     });
-
-    gpii.firstDiscovery.tts.fdHookup.bindKeypress = function (elm, keyCode, func) {
-        $(elm).keypress(function (e) {
-            if (e.keyCode === keyCode) {
-                func();
-            }
-        });
-    };
 
     gpii.firstDiscovery.tts.fdHookup.getCurrentPanelInstructions = function (that) {
         return that.panels.eq(that.model.currentPanelNum - 1).find(that.options.panelInstructionsSelector).text();

--- a/tests/all-tests.html
+++ b/tests/all-tests.html
@@ -11,19 +11,20 @@
 
     <script>
     QUnit.testSuites("The First Discovery Tool Tests", [
+        "./html/keyboardShortcut-Tests.html",
         "./html/ttsHookup-Tests.html",
         "./html/tooltip-Tests.html",
         "./html/msgLookup-Tests.html",
         "./html/selfVoicing-Tests.html",
         "./html/navButtons-Tests.html",
         "./html/navIcons-Tests.html",
+        "./html/keyboardInput-Tests.html",
         "./html/stickyKeysAssessment-Tests.html",
         "./html/stickyKeysAdjuster-Tests.html",
         "./html/panels-Tests.html",
         "./html/enactors-Tests.html",
+        "./html/helpButton-Tests.html",
         "./html/firstDiscoveryEditor-Tests.html",
-        "./html/keyboardInput-Tests.html",
-        "./html/helpButton-Tests.html"
     ]);
     </script>
 </head>

--- a/tests/html/firstDiscoveryEditor-Tests.html
+++ b/tests/html/firstDiscoveryEditor-Tests.html
@@ -14,6 +14,7 @@
         <script src="../lib/infusion/test-core/utils/js/IoCTestUtils.js"></script>
 
         <script src="../../src/schemas/schemas.js"></script>
+        <script src="../../src/js/keyboardShortcut.js"></script>
         <script src="../../src/js/ttsHookup.js"></script>
         <script src="../../src/js/tooltip.js"></script>
         <script src="../../src/js/msgLookup.js"></script>
@@ -39,6 +40,8 @@
         <ol id="qunit-tests"></ol>
 
         <!-- Test HTML -->
+
+        <!-- Nav Controls Tests -->
         <div id="gpiic-fd-navControlsTests">
             <div class="gpiic-fd-selfVoicing">
                 <button class="gpiic-fd-selfVoicing-mute left gpii-fd-mute">
@@ -80,6 +83,7 @@
             </div>
         </div>
 
+        <!-- TTS Hookup Tests -->
         <div id="gpiic-fd-ttsHookupTests">
             <div class="gpiic-fd-selfVoicing">
                 <button class="gpiic-fd-selfVoicing-mute left gpii-fd-mute">
@@ -121,6 +125,49 @@
             </div>
         </div>
 
+        <!-- Reset Shortcut Tests -->
+        <div id="gpiic-fd-resetShortcutTests">
+            <div class="gpiic-fd-selfVoicing">
+                <button class="gpiic-fd-selfVoicing-mute left gpii-fd-mute">
+                    <span class="left gpii-fd-icon"></span>
+                    <span class="gpiic-fd-selfVoicing-muteLabel"></span>
+                </button>
+            </div>
+
+            <button class="gpiic-fd-help"></button>
+
+            <section class="gpiic-fd-prefsEditor"></section>
+
+            <div class="gpiic-fd-navButtons">
+                <button id="gpiic-fd-navButtons-back"></button>
+                <button id="gpiic-fd-navButtons-next"></button>
+            </div>
+
+            <div class="gpiic-fd-navIcons text-center gpii-fd-navIcons">
+                <ul>
+                    <li class="gpiic-fd-navIcon gpii-fd-navIcon gpii-fd-lang">
+                        <div class="gpiic-fd-activeIndicator gpii-fd-activeIndicator"></div>
+                        <div class="gpiic-fd-confirmedIndicator gpii-fd-confirmedIndicator"></div>
+                    </li>
+                    <li class="gpiic-fd-navIcon gpii-fd-navIcon-welcome">
+                    </li>
+                    <li class="gpiic-fd-navIcon gpii-fd-navIcon gpii-fd-text">
+                        <div class="gpiic-fd-activeIndicator gpii-fd-activeIndicator"></div>
+                        <div class="gpiic-fd-confirmedIndicator gpii-fd-confirmedIndicator"></div>
+                    </li>
+                    <li class="gpiic-fd-navIcon gpii-fd-navIcon gpii-fd-volume">
+                        <div class="gpiic-fd-activeIndicator gpii-fd-activeIndicator"></div>
+                        <div class="gpiic-fd-confirmedIndicator gpii-fd-confirmedIndicator"></div>
+                    </li>
+                    <li class="gpiic-fd-navIcon gpii-fd-navIcon gpii-fd-contrast">
+                        <div class="gpiic-fd-activeIndicator gpii-fd-activeIndicator"></div>
+                        <div class="gpiic-fd-confirmedIndicator gpii-fd-confirmedIndicator"></div>
+                    </li>
+                </ul>
+            </div>
+        </div>
+
+        <!-- Lang Tests -->
         <div id="gpiic-fd-langTests">
             <div class="gpiic-fd-selfVoicing">
                 <button class="gpiic-fd-selfVoicing-mute left gpii-fd-mute">

--- a/tests/html/keyboardShortcut-Tests.html
+++ b/tests/html/keyboardShortcut-Tests.html
@@ -2,31 +2,29 @@
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <title>keyboardInput Tests</title>
+        <title>Keyboard Shorcut Tests</title>
 
         <link rel="stylesheet" media="screen" href="../lib/infusion/lib/qunit/css/qunit.css" />
+        <link rel="stylesheet" media="screen" href="../../src/css/style.css" />
 
         <script src="../lib/infusion/lib/qunit/js/qunit.js"></script>
         <script src="../../src/lib/infusion/infusion-custom.js"></script>
         <script src="../lib/infusion/test-core/jqUnit/js/jqUnit.js"></script>
         <script src="../lib/infusion/test-core/utils/js/IoCTestUtils.js"></script>
 
-        <script src="../../src/js/tooltip.js"></script>
-        <script src="../../src/js/msgLookup.js"></script>
-        <script src="../../src/js/keyboardInput.js"></script>
+        <script src="../../src/js/keyboardShortcut.js"></script>
         <script src="../js/testUtils.js"></script>
-        <script src="../js/keyboardInputTests.js"></script>
+        <script src="../js/keyboardShortcutTests.js"></script>
     </head>
 
     <body id="body">
-        <h1 id="qunit-header">keyboardInput Tests</h1>
+        <h1 id="qunit-header">Keyboard Shortcut Tests</h1>
         <h2 id="qunit-banner"></h2>
         <div id="qunit-testrunner-toolbar"></div>
         <h2 id="qunit-userAgent"></h2>
         <ol id="qunit-tests"></ol>
 
-        <!-- Test controls -->
-        <input id="gpiic-tests-keyboardInput">
-        <input id="gpiic-tests-other-input">
+        <span class="keyboardShortcut-test"></span>
+
     </body>
 </html>

--- a/tests/html/ttsHookup-Tests.html
+++ b/tests/html/ttsHookup-Tests.html
@@ -8,12 +8,13 @@
 
         <script src="../lib/infusion/lib/qunit/js/qunit.js"></script>
         <script src="../../src/lib/infusion/infusion-custom.js"></script>
-        <script src="../lib/infusion/lib/jquery-ui/js/jquery.simulate.js"></script>
         <script src="../lib/infusion/test-core/jqUnit/js/jqUnit.js"></script>
         <script src="../lib/infusion/test-core/utils/js/IoCTestUtils.js"></script>
 
-
+        <script src="../../src/js/keyboardShortcut.js"></script>
+        <script src="../../src/js/msgLookup.js"></script>
         <script src="../../src/js/ttsHookup.js"></script>
+        <script src="../js/testUtils.js"></script>
         <script src="../js/ttsHookupTests.js"></script>
     </head>
 
@@ -25,6 +26,10 @@
         <ol id="qunit-tests"></ol>
 
         <!-- Test HTML -->
-        <span class="bindKeypress-test"></span>
+        <div class="gpiic-tests-firstDiscovery-tts-fdHookup">
+            <div class="gpiic-fd-prefsEditor-panel">
+                <span class="gpiic-fd-instructions">Test Instructions</span>
+            </div>
+        </div>
     </body>
 </html>

--- a/tests/js/firstDiscoveryEditorTests.js
+++ b/tests/js/firstDiscoveryEditorTests.js
@@ -44,7 +44,14 @@ https://github.com/gpii/universal/LICENSE.txt
             assembledPrefsEditorGrade: {
                 funcName: "gpii.tests.firstDiscovery.getPrefsEditorGrade"
             }
-        }
+        },
+        resetListeners: {
+            "onReset.reload": "fluid.identity"
+        },
+        distributeOptions: [{
+            source: "{that}.options.resetListeners",
+            target: "{that prefsEditor}.options.listeners"
+        }]
     });
 
     gpii.tests.firstDiscovery.getPrefsEditorGrade = function () {
@@ -61,9 +68,11 @@ https://github.com/gpii/universal/LICENSE.txt
 
     // The mapping between the model value of "currentPanelNum" and actual panels
     // 1. language, 2. welcome, 3. audio, 4. text size, 5. contrast
-    gpii.tests.firstDiscovery.runTest = function (msg, container, panelNum, testFunc) {
+    gpii.tests.firstDiscovery.runTest = function (msg, container, panelNum, testFunc, gradeName) {
+        var gradeNames = fluid.makeArray(gradeName || []);
         jqUnit.asyncTest(msg, function () {
             gpii.tests.firstDiscovery(container, {
+                gradeNames: gradeNames,
                 components: {
                     prefsEditorLoader: {
                         options: {
@@ -197,8 +206,32 @@ https://github.com/gpii/universal/LICENSE.txt
         jqUnit.assertEquals("The instruction text should be sourced from the active panel", expected, actual);
     };
 
+    fluid.defaults("gpii.tests.firstDiscovery.reset", {
+        resetListeners: {
+            "onReset.reload": {
+                listener: "jqUnit.assert",
+                args: ["The reset should be triggered"],
+                "this": null,
+                method: null
+            }
+        }
+    });
+
+    gpii.tests.firstDiscovery.testResetShortcut = function () {
+        jqUnit.expect(1);
+
+        var eventObj = {
+            which: gpii.firstDiscovery.keyboardShortcut.key.r,
+            altKey: true,
+            ctrlKey: true
+        };
+
+        gpii.tests.utils.simulateKeyEvent("body", "keydown", eventObj);
+    };
+
     gpii.tests.firstDiscovery.runTest("Init and navigation controls", "#gpiic-fd-navControlsTests", 1, gpii.tests.firstDiscovery.testControls);
     gpii.tests.firstDiscovery.runTest("TTS Hookup", "#gpiic-fd-ttsHookupTests", 3, gpii.tests.firstDiscovery.testTTSHookup);
+    gpii.tests.firstDiscovery.runTest("Reset Shortcut", "#gpiic-fd-resetShortcutTests", 1, gpii.tests.firstDiscovery.testResetShortcut, "gpii.tests.firstDiscovery.reset");
 
     // Test the connection between the top level first discovery editor and the language panel: the language panel resets button positions every
     // time when the panel itself becomes visible to accommodate the possible text or control size changes that cause the shift of button positions.

--- a/tests/js/keyboardInputTests.js
+++ b/tests/js/keyboardInputTests.js
@@ -99,11 +99,11 @@ https://github.com/gpii/universal/LICENSE.txt
     });
 
     gpii.tests.firstDiscovery.triggerKeypress = function (elem, ch) {
-        elem.triggerHandler(jQuery.Event("keypress", { which: ch.charCodeAt(0) }));
+        gpii.tests.utils.simulateKeyEvent(elem, "keypress", { which: ch.charCodeAt(0) });
     };
 
     gpii.tests.firstDiscovery.triggerKeydown = function (elem, keyCode) {
-        elem.triggerHandler(jQuery.Event("keydown", { which: keyCode }));
+        gpii.tests.utils.simulateKeyEvent(elem, "keydown", { which: keyCode });
     };
 
     gpii.tests.firstDiscovery.checkShiftLatchedClass = function (keyboardInput) {

--- a/tests/js/keyboardShortcutTests.js
+++ b/tests/js/keyboardShortcutTests.js
@@ -1,0 +1,155 @@
+/*!
+Copyright 2015 OCAD University
+
+Licensed under the New BSD license. You may not use this file except in
+compliance with this License.
+
+You may obtain a copy of the License at
+https://github.com/gpii/universal/LICENSE.txt
+*/
+
+(function ($, fluid) {
+    "use strict";
+
+    fluid.registerNamespace("gpii.tests.keyboardShortcut");
+
+    gpii.tests.keyboardShortcut.shortcuts = {
+        "a": {
+            key: gpii.firstDiscovery.keyboardShortcut.key.a,
+            modifiers: []
+        },
+        "alt-a": {
+            key: gpii.firstDiscovery.keyboardShortcut.key.a,
+            modifiers: ["altKey"]
+        },
+        "ctrl-a": {
+            key: gpii.firstDiscovery.keyboardShortcut.key.a,
+            modifiers: ["ctrlKey"]
+        },
+        "meta-a": {
+            key: gpii.firstDiscovery.keyboardShortcut.key.a,
+            modifiers: ["metaKey"]
+        },
+        "shift-a": {
+            key: gpii.firstDiscovery.keyboardShortcut.key.a,
+            modifiers: ["shiftKey"]
+        },
+        "alt-ctrl-a": {
+            key: gpii.firstDiscovery.keyboardShortcut.key.a,
+            modifiers: ["altKey", "ctrlKey"]
+        },
+        "alt-meta-a": {
+            key: gpii.firstDiscovery.keyboardShortcut.key.a,
+            modifiers: ["altKey", "metaKey"]
+        },
+        "alt-shift-a": {
+            key: gpii.firstDiscovery.keyboardShortcut.key.a,
+            modifiers: ["altKey", "shiftKey"]
+        },
+        "ctrl-meta-a": {
+            key: gpii.firstDiscovery.keyboardShortcut.key.a,
+            modifiers: ["ctrlKey", "metaKey"]
+        },
+        "ctrl-shift-a": {
+            key: gpii.firstDiscovery.keyboardShortcut.key.a,
+            modifiers: ["ctrlKey", "shiftKey"]
+        },
+        "meta-shift-a": {
+            key: gpii.firstDiscovery.keyboardShortcut.key.a,
+            modifiers: ["metaKey", "shiftKey"]
+        },
+        "alt-ctrl-meta-a": {
+            key: gpii.firstDiscovery.keyboardShortcut.key.a,
+            modifiers: ["altKey", "ctrlKey", "metaKey"]
+        },
+        "alt-ctrl-shift-a": {
+            key: gpii.firstDiscovery.keyboardShortcut.key.a,
+            modifiers: ["altKey", "ctrlKey", "shiftKey"]
+        },
+        "alt-meta-shift-a": {
+            key: gpii.firstDiscovery.keyboardShortcut.key.a,
+            modifiers: ["altKey", "metaKey", "shiftKey"]
+        },
+        "ctrl-meta-shift-a": {
+            key: gpii.firstDiscovery.keyboardShortcut.key.a,
+            modifiers: ["ctrlKey", "metaKey", "shiftKey"]
+        },
+        "alt-ctrl-meta-shift-a": {
+            key: gpii.firstDiscovery.keyboardShortcut.key.a,
+            modifiers: ["altKey", "ctrlKey", "metaKey", "shiftKey"]
+        }
+    };
+
+    gpii.tests.keyboardShortcut.modifiersTestCases = [
+        // none
+        {altKey: false, ctrlKey: false, metaKey: false, shiftKey: false},
+
+        // one
+        {altKey: true, ctrlKey: false, metaKey: false, shiftKey: false},
+        {altKey: false, ctrlKey: true, metaKey: false, shiftKey: false},
+        {altKey: false, ctrlKey: false, metaKey: true, shiftKey: false},
+        {altKey: false, ctrlKey: false, metaKey: false, shiftKey: true},
+
+        // two
+        {altKey: true, ctrlKey: true, metaKey: false, shiftKey: false},
+        {altKey: true, ctrlKey: false, metaKey: true, shiftKey: false},
+        {altKey: true, ctrlKey: false, metaKey: false, shiftKey: true},
+        {altKey: false, ctrlKey: true, metaKey: true, shiftKey: false},
+        {altKey: false, ctrlKey: true, metaKey: false, shiftKey: true},
+        {altKey: false, ctrlKey: false, metaKey: true, shiftKey: true},
+
+        // three
+        {altKey: true, ctrlKey: true, metaKey: true, shiftKey: false},
+        {altKey: true, ctrlKey: true, metaKey: false, shiftKey: true},
+        {altKey: true, ctrlKey: false, metaKey: true, shiftKey: true},
+        {altKey: false, ctrlKey: true, metaKey: true, shiftKey: true},
+
+        // four
+        {altKey: true, ctrlKey: true, metaKey: true, shiftKey: true}
+    ];
+
+    gpii.tests.keyboardShortcut.handlerFnCreator = function (fireRecord, recordName) {
+        return function () {
+            fireRecord[recordName] = (fireRecord[recordName] || 0) + 1;
+        };
+    };
+
+    jqUnit.test("gpii.firstDiscovery.keyboardShortcut.bindShortcut", function () {
+        var elm = $(".keyboardShortcut-test");
+        var fireRecord = {};
+        var expectedRecord = {
+            "a": 1,
+            "alt-a": 1,
+            "ctrl-a": 1,
+            "meta-a": 1,
+            "shift-a": 1,
+            "alt-ctrl-a": 1,
+            "alt-meta-a": 1,
+            "alt-shift-a": 1,
+            "ctrl-meta-a": 1,
+            "ctrl-shift-a": 1,
+            "meta-shift-a": 1,
+            "alt-ctrl-meta-a": 1,
+            "alt-ctrl-shift-a": 1,
+            "alt-meta-shift-a": 1,
+            "ctrl-meta-shift-a": 1,
+            "alt-ctrl-meta-shift-a": 1
+        };
+
+        // bind shortcuts
+        fluid.each(gpii.tests.keyboardShortcut.shortcuts, function (shortcuts, shortcutName) {
+            gpii.firstDiscovery.keyboardShortcut.bindShortcut(elm, shortcuts.key, shortcuts.modifiers, gpii.tests.keyboardShortcut.handlerFnCreator(fireRecord, shortcutName));
+        });
+
+        // run through key strokes
+        fluid.each(gpii.firstDiscovery.keyboardShortcut.key, function (keyCode) {
+            fluid.each(gpii.tests.keyboardShortcut.modifiersTestCases, function (modifiers) {
+                var eventObj = $.extend(true, {which: keyCode}, modifiers);
+                gpii.tests.utils.simulateKeyEvent(elm, "keydown", eventObj);
+            });
+        });
+
+        jqUnit.assertDeepEq("The shortcuts should have been triggered the correct number of times", expectedRecord, fireRecord);
+    });
+
+})(jQuery, fluid);

--- a/tests/js/testUtils.js
+++ b/tests/js/testUtils.js
@@ -37,6 +37,10 @@ https://github.com/gpii/universal/LICENSE.txt
         radioButtons.eq(idx).click();
     };
 
+    gpii.tests.utils.simulateKeyEvent = function (elm, keyEvent, eventObj) {
+        $(elm).triggerHandler(jQuery.Event(keyEvent, eventObj));
+    };
+
     gpii.tests.utils.verifyRadioButtonRendering = function (inputs, inputLabels, labelText, selection) {
         fluid.each(inputLabels, function (elm, idx) {
             elm = $(elm);

--- a/tests/js/ttsHookupTests.js
+++ b/tests/js/ttsHookupTests.js
@@ -13,17 +13,109 @@ https://github.com/gpii/universal/LICENSE.txt
 
     fluid.registerNamespace("gpii.tests");
 
-    jqUnit.test("gpii.firstDiscovery.tts.fdHookup.bindKeypress", function () {
-        jqUnit.expect(1);
-        var elm = $(".bindKeypress-test");
-        var keyCode = 104; // 'h'
+    fluid.defaults("gpii.tests.mock.firstDiscoveryEditor", {
+        gradeNames: ["fluid.viewRelayComponent", "autoInit"],
+        selectors: {
+            panel: ".gpiic-fd-prefsEditor-panel"
+        },
+        model: {
+            currentPanelNum: 1
+        },
+        components: {
+            selfVoicing: {
+                type: "fluid.standardComponent",
+                options: {
+                    gradeNames: ["gpii.firstDiscovery.msgLookup"],
+                    model: {
+                        enabled: true
+                    },
+                    messageBase: {
+                        "panelMsg": "This is step %currentPanel of %numPanels. %instructions Press 'h' for help."
+                    },
+                    invokers: {
+                        queueSpeech: "{firstDiscoveryEditor}.events.onTestQueueSpeech.fire"
+                    }
+                }
+            }
+        },
+        events: {
+            onTestQueueSpeech: null
+        },
+        listeners: {
+            "onCreate.setPanels": {
+                listener: "fluid.set",
+                args: ["{that}", "panels", "{that}.dom.panel"],
+                priority: "first"
+            }
+        }
+    });
 
-        gpii.firstDiscovery.tts.fdHookup.bindKeypress(elm, keyCode, function () {
-            jqUnit.assert("The keypress function should have exectued");
-        });
+    fluid.defaults("gpii.tests.firstDiscovery.tts.fdHookup", {
+        gradeNames: ["gpii.tests.mock.firstDiscoveryEditor", "gpii.firstDiscovery.tts.fdHookup", "autoInit"]
+    });
 
-        // simulate the keypress
-        elm.simulate("keypress", {keyCode: keyCode});
+    fluid.defaults("gpii.tests.fdHookupTests", {
+        gradeNames: ["fluid.test.testEnvironment", "autoInit"],
+        components: {
+            fdHookup: {
+                type: "gpii.tests.firstDiscovery.tts.fdHookup",
+                container: ".gpiic-tests-firstDiscovery-tts-fdHookup"
+            },
+            ttsHookupTester: {
+                type: "gpii.tests.ttsHookupTester"
+            }
+        }
+    });
+
+    fluid.defaults("gpii.tests.ttsHookupTester", {
+        gradeNames: ["fluid.test.testCaseHolder", "autoInit"],
+        modules: [{
+            name: "Tests the fdHookup component",
+            tests: [{
+                expect: 1,
+                name: "gpii.firstDiscovery.tts.fdHookup.getCurrentPanelInstructions",
+                type: "test",
+                func: "gpii.tests.ttsHookupTester.verifyGetCurrentPanelInstructions",
+                args: ["{fdHookup}", "Test Instructions"]
+            }, {
+                expect: 3,
+                name: "TTS message tests",
+                sequence: [{
+                    func: "{fdHookup}.selfVoicing.speakPanelMessage"
+                }, {
+                    listener: "jqUnit.assertEquals",
+                    args: [
+                        "The correct message for the panel should be sent to the TTS",
+                        "This is step 1 of 1. Test Instructions Press 'h' for help.",
+                        "{arguments}.0"
+                    ],
+                    event: "{fdHookup}.events.onTestQueueSpeech"
+                }, {
+                    func: "{fdHookup}.selfVoicing.speakPanelInstructions"
+                }, {
+                    listener: "jqUnit.assertEquals",
+                    args: ["The panel instructions should be sent to the TTS", "Test Instructions", "{arguments}.0"],
+                    event: "{fdHookup}.events.onTestQueueSpeech"
+                }, {
+                    func: "gpii.tests.utils.simulateKeyEvent",
+                    args: ["body", "keydown", {which: gpii.firstDiscovery.keyboardShortcut.key.h}]
+                }, {
+                    listener: "jqUnit.assertEquals",
+                    args: ["The panel instructions should be sent to the TTS", "Test Instructions", "{arguments}.0"],
+                    event: "{fdHookup}.events.onTestQueueSpeech"
+                }]
+            }]
+        }]
+    });
+
+    gpii.tests.ttsHookupTester.verifyGetCurrentPanelInstructions = function (that, expected) {
+        jqUnit.assertEquals("The current panel instructions should be retrieved correctly", expected, gpii.firstDiscovery.tts.fdHookup.getCurrentPanelInstructions(that));
+    };
+
+    $(document).ready(function () {
+        fluid.test.runTests([
+            "gpii.tests.fdHookupTests"
+        ]);
     });
 
 })(jQuery, fluid);

--- a/tests/js/ttsHookupTests.js
+++ b/tests/js/ttsHookupTests.js
@@ -73,7 +73,7 @@ https://github.com/gpii/universal/LICENSE.txt
             name: "Tests the fdHookup component",
             tests: [{
                 expect: 1,
-                name: "gpii.firstDiscovery.tts.fdHookup.getCurrentPanelInstructions",
+                name: "Test the gpii.firstDiscovery.tts.fdHookup.getCurrentPanelInstructions function",
                 type: "test",
                 func: "gpii.tests.ttsHookupTester.verifyGetCurrentPanelInstructions",
                 args: ["{fdHookup}", "Test Instructions"]


### PR DESCRIPTION
Added a keyboard shortcut (ctrl-option/alt-r) to reset the the first discovery tool

http://issues.fluidproject.org/browse/FLOE-325