### PR TITLE
FLOE-346: Disabling at min

### DIFF
--- a/src/js/panels.js
+++ b/src/js/panels.js
@@ -106,8 +106,9 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     };
 
     gpii.firstDiscovery.panel.ranged.updateButtonState = function (that) {
-        var isMax = that.model.value >= that.options.range.max;
-        var isMin = that.model.value <= that.options.range.min;
+        // assumes that values can't go out of range (based on range limit modelRelay)
+        var isMax = fluid.model.isSameValue(that.model.value, that.options.range.max);
+        var isMin = fluid.model.isSameValue(that.model.value, that.options.range.min);
 
         that.locate("increase").prop("disabled", isMax);
         that.locate("decrease").prop("disabled", isMin);

--- a/src/js/panels.js
+++ b/src/js/panels.js
@@ -31,15 +31,39 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             max: 2
         },
         step: 0.1,
-        modelRelay: {
+        modelRelay: [{
             target: "value",
             singleTransform: {
                 type: "fluid.transforms.limitRange",
                 input: "{that}.model.value",
                 min: "{that}.options.range.min",
-                max: "{that}.options.prange.max"
+                max: "{that}.options.range.max"
             }
-        },
+        // TODO: Due to FLUID-5669 the isMax and isMin
+        // transformations are performed using the fluid.transforms.free
+        // transformation. Once FLUID-5669 has been addressed, it should be
+        // possible to simply make use of fluid.transforms.binaryOp.
+        }, {
+            target: "isMax",
+            singleTransform: {
+                type: "fluid.transforms.free",
+                args: {
+                    "value": "{that}.model.value",
+                    "limit": "{that}.options.range.max"
+                },
+                func: "gpii.firstDiscovery.panel.ranged.isAtLimit"
+            }
+        }, {
+            target: "isMin",
+            singleTransform: {
+                type: "fluid.transforms.free",
+                args: {
+                    "value": "{that}.model.value",
+                    "limit": "{that}.options.range.min"
+                },
+                func: "gpii.firstDiscovery.panel.ranged.isAtLimit"
+            }
+        }],
         selectors: {
             rangeInstructions: ".gpiic-fd-range-instructions",
             meter: ".gpiic-fd-range-indicator",
@@ -86,16 +110,16 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             "afterRender.updateMeter": "{that}.updateMeter"
         },
         modelListeners: {
-            value: [{
+            value: {
                 listener: "{that}.updateMeter",
                 excludeSource: "init"
-            }, {
-                listener: "gpii.firstDiscovery.panel.ranged.updateButtonState",
-                excludeSource: "init",
-                args: ["{that}"]
-            }]
+            }
         }
     });
+
+    gpii.firstDiscovery.panel.ranged.isAtLimit = function (model) {
+        return fluid.model.isSameValue(model.limit, model.value);
+    };
 
     gpii.firstDiscovery.panel.ranged.step = function (that, reverse) {
         that.tooltip.close();   // close the existing tooltip before the panel is re-rendered
@@ -106,12 +130,8 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     };
 
     gpii.firstDiscovery.panel.ranged.updateButtonState = function (that) {
-        // assumes that values can't go out of range (based on range limit modelRelay)
-        var isMax = fluid.model.isSameValue(that.model.value, that.options.range.max);
-        var isMin = fluid.model.isSameValue(that.model.value, that.options.range.min);
-
-        that.locate("increase").prop("disabled", isMax);
-        that.locate("decrease").prop("disabled", isMin);
+        that.locate("increase").prop("disabled", that.model.isMax);
+        that.locate("decrease").prop("disabled", that.model.isMin);
     };
 
     gpii.firstDiscovery.panel.ranged.updateMeter = function (that, value) {

--- a/src/messages/textSize.json
+++ b/src/messages/textSize.json
@@ -1,5 +1,5 @@
 {
-    "rangeInstructions": "Adjust the text and controls to a size you like best.",
+    "rangeInstructions": "Adjust the text and buttons to a size you like best.",
     "increaseLabel": "larger",
     "decreaseLabel": "smaller"
 }

--- a/tests/js/panelsTests.js
+++ b/tests/js/panelsTests.js
@@ -226,6 +226,10 @@ https://github.com/gpii/universal/LICENSE.txt
         },
         model: {
             value: 1
+        },
+        modelListeners: {
+            // rerenders on modelChange like panel behaves in the prefsEditor
+            "value": "{that}.refreshView"
         }
     });
 
@@ -252,7 +256,7 @@ https://github.com/gpii/universal/LICENSE.txt
         modules: [{
             name: "Test the text sizer settings panel",
             tests: [{
-                expect: 11,
+                expect: 17,
                 name: "Test the rendering of the text size panel",
                 sequence: [{
                     func: "{textSize}.refreshView"
@@ -280,7 +284,7 @@ https://github.com/gpii/universal/LICENSE.txt
                 }, {
                     listener: "gpii.tests.textSizeTester.verifyButtonStates",
                     args: ["{textSize}", true, false],
-                    spec: {path: "value", priority: "last"},
+                    spec: {path: "isMax", priority: "last"},
                     changeEvent: "{textSize}.applier.modelChanged"
                 }, {
                     func: "{textSize}.applier.change",
@@ -288,7 +292,7 @@ https://github.com/gpii/universal/LICENSE.txt
                 }, {
                     listener: "gpii.tests.textSizeTester.verifyButtonStates",
                     args: ["{textSize}", false, true],
-                    spec: {path: "value", priority: "last"},
+                    spec: {path: "isMin", priority: "last"},
                     changeEvent: "{textSize}.applier.modelChanged"
                 }, {
                     func: "{textSize}.applier.change",
@@ -296,7 +300,7 @@ https://github.com/gpii/universal/LICENSE.txt
                 }, {
                     listener: "gpii.tests.textSizeTester.verifyButtonStates",
                     args: ["{textSize}", false, false],
-                    spec: {path: "value", priority: "last"},
+                    spec: {path: "isMin", priority: "last"},
                     changeEvent: "{textSize}.applier.modelChanged"
                 }]
             }]
@@ -314,11 +318,14 @@ https://github.com/gpii/universal/LICENSE.txt
     };
 
     gpii.tests.textSizeTester.verifyModel = function (that, expectedModel) {
-        jqUnit.assertEquals("The model value should be set correctly", expectedModel, that.model.value);
+        jqUnit.assertEquals("The model value " + expectedModel + " should be set correctly", expectedModel, that.model.value);
     };
 
     gpii.tests.textSizeTester.verifyButtonStates = function (that, increaseDisabled, decreaseDisabled) {
+        jqUnit.assertEquals("The isMax model value should be set correctly", increaseDisabled, that.model.isMax);
         jqUnit.assertEquals("The increase button should have the correct enabled/disabled state", increaseDisabled, that.locate("increase").prop("disabled"));
+
+        jqUnit.assertEquals("The isMin model value should be set correctly", decreaseDisabled, that.model.isMin);
         jqUnit.assertEquals("The decrease button should have the correct enabled/disabled state", decreaseDisabled, that.locate("decrease").prop("disabled"));
     };
 


### PR DESCRIPTION
The min value wasn't disabling the button due to floating point inaccuracies. This has been taken care of by using fluid.model.isSameValue.

Also modified the text for the textSize panel.

http://issues.fluidproject.org/browse/FLOE-346