### PR TITLE
FLOE-347: Enabling/Disabling the speech rate panel with the speak setting

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -314,7 +314,7 @@ button {
 .gpii-fd .gpii-fd-range-disabledMsg {
     line-height: 1.1;
     border: 1px solid #425165;
-    padding: 2rem 2rem;
+    padding: 1.5rem 2rem;
 }
 
 /* language controls */

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -254,7 +254,7 @@ button {
     border-color: #000000 !important;
 }
 
-/* text size increase/decrease controls */
+/* range increase/decrease controls */
 .gpii-fd-increase, .gpii-fd-decrease {
     width: 6rem;
     height: 6rem;
@@ -308,6 +308,13 @@ button {
 }
 .gpii-fd-decrease .gpii-fd-icon:before {
     content: "\e604";
+}
+
+/* range disabledMsg */
+.gpii-fd .gpii-fd-range-disabledMsg {
+    line-height: 1.1;
+    border: 1px solid #425165;
+    padding: 2rem 2rem;
 }
 
 /* language controls */

--- a/src/html/rangeWithDisabledMsgTemplate.html
+++ b/src/html/rangeWithDisabledMsgTemplate.html
@@ -23,3 +23,4 @@
         <div class="gpiic-fd-range-min small-offset-3 small-1 columns gpii-fd-label-min">min</div>
     </div>
 </div>
+<p class="gpiic-fd-range-disabledMsg gpii-fd-range-disabledMsg"></p>

--- a/src/js/panels.js
+++ b/src/js/panels.js
@@ -66,13 +66,14 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         }],
         selectors: {
             rangeInstructions: ".gpiic-fd-range-instructions",
+            controls: ".gpiic-fd-range-controls",
             meter: ".gpiic-fd-range-indicator",
             max: ".gpiic-fd-range-max",
             min: ".gpiic-fd-range-min",
             increase: ".gpiic-fd-range-increase",
             decrease: ".gpiic-fd-range-decrease"
         },
-        selectorsToIgnore: ["meter", "increase", "decrease"],
+        selectorsToIgnore: ["controls", "meter", "increase", "decrease"],
         tooltipContentMap: {
             "increase": "increaseLabel",
             "decrease": "decreaseLabel"
@@ -143,6 +144,41 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         var percentage = ((value - range.min) / (range.max - range.min)) * 100;
         that.locate("meter").css("height", percentage + "%");
     };
+
+    fluid.defaults("gpii.firstDiscovery.panel.rangedWithDisabledMsg", {
+        gradeNames: ["gpii.firstDiscovery.panel.ranged", "autoInit"],
+        selectors: {
+            disabledMsg: ".gpiic-fd-range-disabledMsg"
+        },
+        protoTree: {
+            rangeInstructions: {messagekey: "rangeInstructions"},
+            max: {messagekey: "maxLabel"},
+            min: {messagekey: "minLabel"},
+            disabledMsg: {messagekey: "disabledMsg"}
+        },
+        listeners: {
+            "afterRender.toggleDisplay": {
+                listener: "{that}.toggleDisplay",
+                priority: "first",
+                args: ["{that}.model.enabled"]
+            }
+        },
+        invokers: {
+            toggleDisplay: {
+                funcName: "gpii.firstDiscovery.panel.rangedWithDisabledMsg.toggleDisplay",
+                args: ["{that}", "{arguments}.0"]
+            }
+        }
+    });
+
+    gpii.firstDiscovery.panel.rangedWithDisabledMsg.toggleDisplay = function (that, isEnabled) {
+        that.locate("controls").toggle(isEnabled);
+        that.locate("disabledMsg").toggle(!isEnabled);
+    };
+
+    /*
+     * Keyboard Panel
+     */
 
     fluid.defaults("gpii.firstDiscovery.panel.keyboard", {
         gradeNames: ["fluid.prefs.panel", "autoInit"],
@@ -310,7 +346,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
      * Speech rate panel
      */
     fluid.defaults("gpii.firstDiscovery.panel.speechRate", {
-        gradeNames: ["gpii.firstDiscovery.panel.ranged", "autoInit"],
+        gradeNames: ["gpii.firstDiscovery.panel.rangedWithDisabledMsg", "autoInit"],
         preferenceMap: {
             "gpii.firstDiscovery.speechRate": {
                 "model.value": "default",
@@ -318,6 +354,12 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 "range.max": "maximum",
                 "step": "divisibleBy"
             }
+        }
+    });
+
+    fluid.defaults("gpii.firstDiscovery.panel.speechRate.prefsEditorConnection", {
+        model: {
+            enabled: "{prefsEditor}.model.gpii_firstDiscovery_speak"
         }
     });
 

--- a/src/messages/speechRate.json
+++ b/src/messages/speechRate.json
@@ -3,5 +3,6 @@
     "maxLabel": "fast",
     "minLabel": "slow",
     "increaseLabel": "faster",
-    "decreaseLabel": "slower"
+    "decreaseLabel": "slower",
+    "disabledMsg": "If you want to use this option, turn on \"speak text aloud\" on the previous screen. Press the back button to get there or select the \"turn voice ON\" button above."
 }

--- a/src/schemas/schemas.js
+++ b/src/schemas/schemas.js
@@ -85,8 +85,9 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 "panel": {
                     "type": "gpii.firstDiscovery.panel.speechRate",
                     "container": ".gpiic-fd-prefsEditor-panel-speechRate",
-                    "template": "%prefix/rangeTemplate.html",
-                    "message": "%prefix/speechRate.json"
+                    "template": "%prefix/rangeWithDisabledMsgTemplate.html",
+                    "message": "%prefix/speechRate.json",
+                    "gradeNames": ["gpii.firstDiscovery.panel.speechRate.prefsEditorConnection"]
                 }
             },
             "contrast": {

--- a/tests/html/panels-Tests.html
+++ b/tests/html/panels-Tests.html
@@ -92,7 +92,7 @@
         <!-- Test Speech Rate Panel -->
         <section class="gpiic-fd-speechRate gpii-adjusterContainer-size gpii-main gpii-current">
             <p class="gpiic-fd-range-instructions gpiic-fd-instructions gpii-fd-instructions"></p>
-            <div class="row gpii-fd-controls">
+            <div class="gpiic-fd-range-controls row gpii-fd-controls">
                 <div class="row">
                     <div class="gpiic-fd-range-max small-offset-3 small-1 columns gpii-fd-label-max">max</div>
                 </div>
@@ -116,6 +116,7 @@
                     <div class="gpiic-fd-range-min small-offset-3 small-1 columns gpii-fd-label-min">min</div>
                 </div>
             </div>
+            <p class="gpiic-fd-range-disabledMsg gpii-fd-range-disabledMsg"></p>
         </section>
 
         <!-- Test Contrast Panel -->


### PR DESCRIPTION
The speech rate panel is enabled when speak text is enabled, and shows a disabled message when speak text is disabled.

http://issues.fluidproject.org/browse/FLOE-347