### PR TITLE
FLOE-339: Speak unlatch state

### DIFF
--- a/src/js/keyboardInput.js
+++ b/src/js/keyboardInput.js
@@ -128,7 +128,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 args: ["{that}", "{that}.container"]
             },
             "toggleShiftLatched": {
-                funcName: "gpii.firstDiscovery.keyboardInputTts.toggleShiftLatched",
+                funcName: "gpii.firstDiscovery.keyboardInput.toggleShiftLatched",
                 args: ["{that}"]
             }
         },
@@ -249,6 +249,10 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         }
     };
 
+    gpii.firstDiscovery.keyboardInput.toggleShiftLatched = function (that) {
+        that.applier.change("shiftLatched", !(that.model.shiftLatched));
+    };
+
     // The gpii.firstDiscovery.keyboardInputTts mixin grade adds
     // self-voicing to the keyboardInput grade. keyboardInputTts
     // relies on the availablility of a component with the
@@ -314,10 +318,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     gpii.firstDiscovery.keyboardInputTts.speakShiftState = function (that, latchedMsg, unlatchedMsg) {
         var msg = that.model.shiftLatched ? latchedMsg : unlatchedMsg;
         that.speak(msg);
-    };
-
-    gpii.firstDiscovery.keyboardInputTts.toggleShiftLatched = function (that) {
-        that.applier.change("shiftLatched", !(that.model.shiftLatched));
     };
 
 })();

--- a/src/js/keyboardInput.js
+++ b/src/js/keyboardInput.js
@@ -150,6 +150,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 args: ["{that}.container", "{arguments}.0"],
                 priority: "last"
             },
+            "shiftLatchChange.toggleShiftLatched": "{that}.toggleShiftLatched",
             // begin TOOLTIP HANDLER CONFIGURATION
             //
             // We want to control the tooltip opening ourselves so we
@@ -183,8 +184,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 method: "on",
                 args: ["focusin.closeTooltip", "{that}.tooltip.close"],
                 priority: 1
-            },
-            "shiftLatchChange.toggleShiftLatched": "{that}.toggleShiftLatched"
+            }
             // END TOOLTIP HANDLER CONFIGURATION
         },
         components: {

--- a/src/js/keyboardInput.js
+++ b/src/js/keyboardInput.js
@@ -293,11 +293,11 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 priority: 1
             },
             // The shiftLatchChange.speakShiftState listener has
-            // a priority of "last" as it must happen after the model
+            // a priority of -10 as it must happen after the model
             // is changed via the shiftLatchChange.toggleShiftLatched listener
             "shiftLatchChange.speakShiftState": {
                 listener: "{that}.speakShiftState",
-                priority: "last"
+                priority: -10
             }
         }
     });

--- a/src/messages/keyboard.json
+++ b/src/messages/keyboard.json
@@ -19,5 +19,6 @@
     "turnOnTooltip": "Select to turn Sticky Keys on",
     "turnOffTooltip": "Select to turn Sticky Keys off",
 
-    "shiftLatched": "shift is on"
+    "shiftLatched": "shift is on",
+    "shiftUnlatched": "shift is off"
 }

--- a/tests/js/keyboardInputTests.js
+++ b/tests/js/keyboardInputTests.js
@@ -591,7 +591,8 @@ https://github.com/gpii/universal/LICENSE.txt
     fluid.defaults("gpii.tests.firstDiscovery.keyboardInputWithTts", {
         gradeNames: ["gpii.tests.firstDiscovery.keyboardInput", "gpii.firstDiscovery.keyboardInputTts", "autoInit"],
         messageBase: {
-            "shiftLatched": "shiftLatched message"
+            "shiftLatched": "shiftLatched message",
+            "shiftUnlatched": "shiftUnlatched message"
         },
         invokers: {
             speak: {
@@ -729,7 +730,7 @@ https://github.com/gpii/universal/LICENSE.txt
                 },
                 {
                     name: "Check key presses and shift spoken when sticky keys is on",
-                    expect: 4,
+                    expect: 6,
                     sequence: [
                         {
                             func: "{keyboardInput}.applier.change",
@@ -748,6 +749,26 @@ https://github.com/gpii/universal/LICENSE.txt
                             event: "{keyboardInput}.events.speak",
                             listener: "gpii.tests.firstDiscovery.keyboardInputTts.checkSpoken",
                             args: ["{keyboardInput}", "a"]
+                        },
+                        {
+                            func: "gpii.tests.firstDiscovery.triggerKeydown",
+                            args: ["{keyboardInput}.container",
+                                   "{keyboardInput}.keymap.shiftKeyCode"]
+                        },
+                        {
+                            event: "{keyboardInput}.events.speak",
+                            listener: "gpii.tests.firstDiscovery.keyboardInputTts.checkSpoken",
+                            args: ["{keyboardInput}", "shiftLatched message"]
+                        },
+                        {
+                            func: "gpii.tests.firstDiscovery.triggerKeydown",
+                            args: ["{keyboardInput}.container",
+                                   "{keyboardInput}.keymap.shiftKeyCode"]
+                        },
+                        {
+                            event: "{keyboardInput}.events.speak",
+                            listener: "gpii.tests.firstDiscovery.keyboardInputTts.checkSpoken",
+                            args: ["{keyboardInput}", "shiftUnlatched message"]
                         },
                         {
                             func: "gpii.tests.firstDiscovery.triggerKeydown",


### PR DESCRIPTION
Speak a message indicating that "shift" is unlatched when "shift" is pressed twice in a row.

http://issues.fluidproject.org/browse/FLOE-339