### PR TITLE
FLOE-348: Reduced max speech rate to 2

### DIFF
--- a/src/schemas/schemas.js
+++ b/src/schemas/schemas.js
@@ -198,7 +198,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                 "type": "number",
                 "default": 1,
                 "minimum": 0.1,
-                "maximum": 10,
+                "maximum": 2, // The spec allows for up to 10, but in chrome 2 seems to be the upper bound.
                 "divisibleBy": 0.1
             }
         }


### PR DESCRIPTION
While the spec allows for up to 10, chrome's default synthesizer doesn't seem to support anything past 2 (it will no longer vocalize past this rate).

http://issues.fluidproject.org/browse/FLOE-348?src=confmacro