### PR TITLE
FLOE-368: Set the default locale, so it can find our english language files

### DIFF
--- a/src/js/firstDiscoveryEditor.js
+++ b/src/js/firstDiscoveryEditor.js
@@ -21,6 +21,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
      */
     fluid.defaults("gpii.firstDiscovery.firstDiscoveryEditor", {
         gradeNames: ["gpii.firstDiscovery.tts.fdHookup", "fluid.prefs.prefsEditorLoader", "autoInit"],
+        defaultLocale: "en-US",
         components: {
             selfVoicing: {
                 container: "{that}.dom.selfVoicing",

--- a/src/js/firstDiscoveryEditor.js
+++ b/src/js/firstDiscoveryEditor.js
@@ -21,7 +21,17 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
      */
     fluid.defaults("gpii.firstDiscovery.firstDiscoveryEditor", {
         gradeNames: ["gpii.firstDiscovery.tts.fdHookup", "fluid.prefs.prefsEditorLoader", "autoInit"],
-        defaultLocale: "en-US",
+        defaultLocale: {
+            expander: {
+                funcName: "fluid.get",
+                args: [{
+                    expander: {
+                        funcName: "fluid.defaults",
+                        args: ["gpii.firstDiscovery.schemas.language"]
+                    }
+                }, ["schema", "properties", "gpii.firstDiscovery.language", "default"]]
+            }
+        },
         components: {
             selfVoicing: {
                 container: "{that}.dom.selfVoicing",

--- a/tests/js/firstDiscoveryEditorTests.js
+++ b/tests/js/firstDiscoveryEditorTests.js
@@ -286,8 +286,7 @@ https://github.com/gpii/universal/LICENSE.txt
 
     gpii.tests.firstDiscovery.testDefaultLocale = function (that) {
         var locale = that.prefsEditorLoader.options.defaultLocale;
-        var expectedLocale = fluid.get(fluid.defaults("gpii.firstDiscovery.schemas.language"), ["schema", "properties", "gpii.firstDiscovery.language", "default"]);
-        jqUnit.assertEquals("default locale is as expected", expectedLocale, locale);
+        jqUnit.assertEquals("default locale is as expected", "en-US", locale);
     };
 
 

--- a/tests/js/firstDiscoveryEditorTests.js
+++ b/tests/js/firstDiscoveryEditorTests.js
@@ -284,6 +284,13 @@ https://github.com/gpii/universal/LICENSE.txt
         });
     };
 
+    gpii.tests.firstDiscovery.testDefaultLocale = function (that) {
+        var locale = that.prefsEditorLoader.options.defaultLocale;
+        var expectedLocale = fluid.get(fluid.defaults("gpii.firstDiscovery.schemas.language"), ["schema", "properties", "gpii.firstDiscovery.language", "default"]);
+        jqUnit.assertEquals("default locale is as expected", expectedLocale, locale);
+    };
+
+
     fluid.defaults("gpii.tests.firstDiscovery.langTester", {
         gradeNames: ["fluid.test.testCaseHolder", "autoInit"],
         testData: {
@@ -315,6 +322,16 @@ https://github.com/gpii/universal/LICENSE.txt
                     listener: "gpii.tests.firstDiscovery.testChangedButtonTops",
                     args: ["{firstDiscovery}", "{that}.buttonTops"],
                     event: "{langTests}.events.onButtonTopsReady"
+                }]
+            }]
+        },{
+            name: "Test locales",
+            tests: [{
+                expect: 1,
+                name: "Default Locale",
+                sequence: [{
+                    func: "gpii.tests.firstDiscovery.testDefaultLocale",
+                    args: ["{firstDiscovery}", "{that}"]
                 }]
             }]
         }]


### PR DESCRIPTION
This will fix the problem with local instances not handling un-implemented languages as well