### PR TITLE
FLOE-408: Removed an invalid comment.

### DIFF
--- a/src/js/panels.js
+++ b/src/js/panels.js
@@ -1011,10 +1011,6 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     });
 
     gpii.firstDiscovery.panel.contrast.style = function (labels, theme, defaultThemeName, style) {
-        // TODO: A potential further improvement would be to use a utility such as the one in the video player to
-        // make this automatically model bound.
-        // see: https://github.com/fluid-project/videoPlayer/blob/master/js/VideoPlayer_showHide.js
-        // see: https://issues.fluidproject.org/browse/FLOE-408
         fluid.each(labels, function (label, index) {
             label = $(label);
 


### PR DESCRIPTION
The comment is no longer valid since style() function doesn't need to be bound with a model path. It should only be called when the panel is rendered to apply button styles.